### PR TITLE
Implemented JAX Bidirectional LSTM example using Pytorch

### DIFF
--- a/examples/LSTM/lstm_reference.ipynb
+++ b/examples/LSTM/lstm_reference.ipynb
@@ -1,0 +1,417 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\1alex\\Desktop\\mlax\\mlax-env\\lib\\site-packages\\tqdm\\auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import torch\n",
+    "from torch import nn, optim\n",
+    "from torch.utils.data import DataLoader\n",
+    "import torchvision\n",
+    "\n",
+    "import numpy as np\n",
+    "from datasets import load_dataset\n",
+    "from tokenizers import Tokenizer"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Load in the SNLI dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snli_train = load_dataset(\"snli\", cache_dir=\"../data\", split=\"train\").filter(lambda d: d[\"label\"] != -1)\n",
+    "snli_test = load_dataset(\"snli\", cache_dir=\"../data\", split=\"test\").filter(lambda d: d[\"label\"] != -1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'premise': 'A person on a horse jumps over a broken down airplane.', 'hypothesis': 'A person is training his horse for a competition.', 'label': 1}\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(snli_train[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tokenize datasets using a pretrained tokenizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenization(batch):\n",
+    "    encodings = tokenizer.encode_batch(\n",
+    "        list(zip(batch[\"premise\"], batch[\"hypothesis\"]))\n",
+    "    )\n",
+    "    del batch[\"premise\"]\n",
+    "    del batch[\"hypothesis\"]\n",
+    "    batch[\"ids\"] = [encoding.ids for encoding in encodings]\n",
+    "    batch[\"type_ids\"] = [encoding.type_ids for encoding in encodings]\n",
+    "    batch[\"mask\"] = [\n",
+    "        [bool(i) for i in encoding.attention_mask] for encoding in encodings\n",
+    "    ]\n",
+    "    return batch\n",
+    "\n",
+    "seq_len = 128\n",
+    "tokenizer = Tokenizer.from_pretrained(\"roberta-base\")\n",
+    "tokenizer.enable_truncation(seq_len)\n",
+    "tokenizer.enable_padding(length=seq_len)\n",
+    "\n",
+    "snli_train_tokenized = snli_train.map(\n",
+    "    tokenization, batched=True, batch_size=1024\n",
+    ")\n",
+    "snli_test_tokenized = snli_test.map(\n",
+    "    tokenization, batched=True, batch_size=1024\n",
+    ")\n",
+    "snli_train_tokenized.set_format(type=\"numpy\")\n",
+    "snli_test_tokenized.set_format(type=\"numpy\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Batch the SNLI data with Pytorch dataloaders."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2146 39\n"
+     ]
+    }
+   ],
+   "source": [
+    "batch_size = 256\n",
+    "train_dataloader = DataLoader(snli_train_tokenized, batch_size, shuffle=True, num_workers=6)\n",
+    "test_dataloader = DataLoader(snli_test_tokenized, batch_size, num_workers=6)\n",
+    "print(len(train_dataloader), len(test_dataloader))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Build BLSTM model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "BLSTM(\n",
+      "  (embed): Embedding(50265, 192)\n",
+      "  (type_embed): Embedding(2, 192)\n",
+      "  (blstm): LSTM(192, 192, dropout=0.1, bidirectional=True)\n",
+      "  (linear): Linear(in_features=384, out_features=192, bias=True)\n",
+      "  (output_layer): Sequential(\n",
+      "    (0): Flatten(start_dim=1, end_dim=-1)\n",
+      "    (1): Linear(in_features=49152, out_features=3, bias=True)\n",
+      "  )\n",
+      ")\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\1alex\\Desktop\\mlax\\mlax-env\\lib\\site-packages\\torch\\nn\\modules\\rnn.py:71: UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.1 and num_layers=1\n",
+      "  warnings.warn(\"dropout option adds dropout after all but last \"\n"
+     ]
+    }
+   ],
+   "source": [
+    "class BLSTM(nn.Module):\n",
+    "    def __init__(self, vocab_size, embed_size=192, dropout=0.1):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        self.embed = nn.Embedding(vocab_size, embed_size)\n",
+    "        self.type_embed = nn.Embedding(2, embed_size)\n",
+    "        \n",
+    "        self.blstm_first = nn.LSTM(input_size=embed_size, hidden_size=embed_size, dropout=dropout, bidirectional=True)\n",
+    "        self.blstm = nn.LSTM(input_size=embed_size * 2, hidden_size=embed_size, dropout=dropout, bidirectional=True)\n",
+    "\n",
+    "        self.output_layer = nn.Sequential(\n",
+    "            nn.Flatten(),\n",
+    "            nn.Linear(embed_size * seq_len * 2, 3)\n",
+    "        )\n",
+    "    \n",
+    "    def forward(self, batch):\n",
+    "        # calculate embeddings\n",
+    "        ids, type_ids, mask = batch\n",
+    "        embeddings = self.embed(ids)\n",
+    "        type_embeddings = self.type_embed(type_ids)\n",
+    "        embeddings = embeddings + type_embeddings\n",
+    "\n",
+    "        # lstm layers\n",
+    "        output, _ = self.blstm_first(embeddings)\n",
+    "        output, _ = self.blstm(output)\n",
+    "        output, _ = self.blstm(output)\n",
+    "        \n",
+    "        # output layer\n",
+    "        output = self.output_layer(output)\n",
+    "\n",
+    "        # apply masking\n",
+    "        # if mask is not None:\n",
+    "        #     mask = torch.unsqueeze(mask, -1)\n",
+    "        #     output = torch.unsqueeze(output, -1)\n",
+    "        #     output = torch.where(mask, 0, output)\n",
+    "        #     print(output.shape)\n",
+    "        # return output\n",
+    "\n",
+    "    \n",
+    "model = BLSTM(vocab_size=tokenizer.get_vocab_size())\n",
+    "print(model)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define Device."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cuda\n"
+     ]
+    }
+   ],
+   "source": [
+    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "print(device)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define loss function and optimizer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "loss_fn = nn.CrossEntropyLoss()\n",
+    "optimizer = optim.AdamW(model.parameters(), lr=5e-5, weight_decay=1e-2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define training and testing steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_step(X, y):\n",
+    "    with torch.enable_grad():\n",
+    "        loss = loss_fn(model(X), y)\n",
+    "        optimizer.zero_grad()\n",
+    "        loss.backward()\n",
+    "        optimizer.step()\n",
+    "    return loss.item()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test_step(X, y):\n",
+    "    with torch.no_grad():\n",
+    "        preds = model(X)\n",
+    "        loss = loss_fn(preds, y)\n",
+    "    accurate = (preds.argmax(1) == y).type(torch.int).sum()\n",
+    "    return loss.item(), accurate.item()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define training and testing loops."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train(dataloader):\n",
+    "    model.train()\n",
+    "    train_loss = 0.0\n",
+    "    for batch in dataloader:\n",
+    "        ids, type_ids, mask = batch[\"ids\"], batch[\"type_ids\"], batch[\"mask\"]\n",
+    "        ids = ids.to(device)\n",
+    "        type_ids = type_ids.to(device)\n",
+    "        mask = mask.to(device)\n",
+    "        X = (ids, type_ids, mask)\n",
+    "        y = batch[\"label\"].to(device)\n",
+    "        train_loss += train_step(X, y)\n",
+    "\n",
+    "    print(f\"Train loss: {train_loss / len(dataloader)}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def test(dataloader):\n",
+    "    model.eval()\n",
+    "    test_loss, accurate = 0.0, 0\n",
+    "    for batch in dataloader:\n",
+    "        ids, type_ids, mask = batch[\"ids\"], batch[\"type_ids\"], batch[\"mask\"]\n",
+    "        ids = ids.to(device)\n",
+    "        type_ids = type_ids.to(device)\n",
+    "        mask = mask.to(device)\n",
+    "        X = (ids, type_ids, mask)\n",
+    "        y = batch[\"label\"].to(device)\n",
+    "        loss, acc = test_step(X, y)\n",
+    "        test_loss += loss\n",
+    "        accurate += acc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def train_loop(\n",
+    "    train_dataloader,\n",
+    "    test_dataloader,\n",
+    "    epochs,\n",
+    "    test_every\n",
+    "):\n",
+    "    model.to(device)\n",
+    "    for i in range(epochs):\n",
+    "        epoch = (i + 1)\n",
+    "        print(f\"Epoch {epoch}\\n----------------\")\n",
+    "        train(train_dataloader)\n",
+    "        if (epoch % test_every == 0):\n",
+    "            test(test_dataloader)\n",
+    "        print(f\"----------------\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Epoch 1\n",
+      "----------------\n"
+     ]
+    },
+    {
+     "ename": "KeyboardInterrupt",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m                         Traceback (most recent call last)",
+      "Cell \u001b[1;32mIn[14], line 1\u001b[0m\n\u001b[1;32m----> 1\u001b[0m train_loop(train_dataloader, test_dataloader, \u001b[39m1\u001b[39;49m, \u001b[39m5\u001b[39;49m)\n",
+      "Cell \u001b[1;32mIn[13], line 11\u001b[0m, in \u001b[0;36mtrain_loop\u001b[1;34m(train_dataloader, test_dataloader, epochs, test_every)\u001b[0m\n\u001b[0;32m      9\u001b[0m epoch \u001b[39m=\u001b[39m (i \u001b[39m+\u001b[39m \u001b[39m1\u001b[39m)\n\u001b[0;32m     10\u001b[0m \u001b[39mprint\u001b[39m(\u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mEpoch \u001b[39m\u001b[39m{\u001b[39;00mepoch\u001b[39m}\u001b[39;00m\u001b[39m\\n\u001b[39;00m\u001b[39m----------------\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m---> 11\u001b[0m train(train_dataloader)\n\u001b[0;32m     12\u001b[0m \u001b[39mif\u001b[39;00m (epoch \u001b[39m%\u001b[39m test_every \u001b[39m==\u001b[39m \u001b[39m0\u001b[39m):\n\u001b[0;32m     13\u001b[0m     test(test_dataloader)\n",
+      "Cell \u001b[1;32mIn[11], line 11\u001b[0m, in \u001b[0;36mtrain\u001b[1;34m(dataloader)\u001b[0m\n\u001b[0;32m      9\u001b[0m     X \u001b[39m=\u001b[39m (ids, type_ids, mask)\n\u001b[0;32m     10\u001b[0m     y \u001b[39m=\u001b[39m batch[\u001b[39m\"\u001b[39m\u001b[39mlabel\u001b[39m\u001b[39m\"\u001b[39m]\u001b[39m.\u001b[39mto(device)\n\u001b[1;32m---> 11\u001b[0m     train_loss \u001b[39m+\u001b[39m\u001b[39m=\u001b[39m train_step(X, y)\n\u001b[0;32m     13\u001b[0m \u001b[39mprint\u001b[39m(\u001b[39mf\u001b[39m\u001b[39m\"\u001b[39m\u001b[39mTrain loss: \u001b[39m\u001b[39m{\u001b[39;00mtrain_loss\u001b[39m \u001b[39m\u001b[39m/\u001b[39m\u001b[39m \u001b[39m\u001b[39mlen\u001b[39m(dataloader)\u001b[39m}\u001b[39;00m\u001b[39m\"\u001b[39m)\n",
+      "Cell \u001b[1;32mIn[9], line 5\u001b[0m, in \u001b[0;36mtrain_step\u001b[1;34m(X, y)\u001b[0m\n\u001b[0;32m      3\u001b[0m     loss \u001b[39m=\u001b[39m loss_fn(model(X), y)\n\u001b[0;32m      4\u001b[0m     optimizer\u001b[39m.\u001b[39mzero_grad()\n\u001b[1;32m----> 5\u001b[0m     loss\u001b[39m.\u001b[39;49mbackward()\n\u001b[0;32m      6\u001b[0m     optimizer\u001b[39m.\u001b[39mstep()\n\u001b[0;32m      7\u001b[0m \u001b[39mreturn\u001b[39;00m loss\u001b[39m.\u001b[39mitem()\n",
+      "File \u001b[1;32mc:\\Users\\1alex\\Desktop\\mlax\\mlax-env\\lib\\site-packages\\torch\\_tensor.py:487\u001b[0m, in \u001b[0;36mTensor.backward\u001b[1;34m(self, gradient, retain_graph, create_graph, inputs)\u001b[0m\n\u001b[0;32m    477\u001b[0m \u001b[39mif\u001b[39;00m has_torch_function_unary(\u001b[39mself\u001b[39m):\n\u001b[0;32m    478\u001b[0m     \u001b[39mreturn\u001b[39;00m handle_torch_function(\n\u001b[0;32m    479\u001b[0m         Tensor\u001b[39m.\u001b[39mbackward,\n\u001b[0;32m    480\u001b[0m         (\u001b[39mself\u001b[39m,),\n\u001b[1;32m   (...)\u001b[0m\n\u001b[0;32m    485\u001b[0m         inputs\u001b[39m=\u001b[39minputs,\n\u001b[0;32m    486\u001b[0m     )\n\u001b[1;32m--> 487\u001b[0m torch\u001b[39m.\u001b[39;49mautograd\u001b[39m.\u001b[39;49mbackward(\n\u001b[0;32m    488\u001b[0m     \u001b[39mself\u001b[39;49m, gradient, retain_graph, create_graph, inputs\u001b[39m=\u001b[39;49minputs\n\u001b[0;32m    489\u001b[0m )\n",
+      "File \u001b[1;32mc:\\Users\\1alex\\Desktop\\mlax\\mlax-env\\lib\\site-packages\\torch\\autograd\\__init__.py:200\u001b[0m, in \u001b[0;36mbackward\u001b[1;34m(tensors, grad_tensors, retain_graph, create_graph, grad_variables, inputs)\u001b[0m\n\u001b[0;32m    195\u001b[0m     retain_graph \u001b[39m=\u001b[39m create_graph\n\u001b[0;32m    197\u001b[0m \u001b[39m# The reason we repeat same the comment below is that\u001b[39;00m\n\u001b[0;32m    198\u001b[0m \u001b[39m# some Python versions print out the first line of a multi-line function\u001b[39;00m\n\u001b[0;32m    199\u001b[0m \u001b[39m# calls in the traceback and some print out the last line\u001b[39;00m\n\u001b[1;32m--> 200\u001b[0m Variable\u001b[39m.\u001b[39;49m_execution_engine\u001b[39m.\u001b[39;49mrun_backward(  \u001b[39m# Calls into the C++ engine to run the backward pass\u001b[39;49;00m\n\u001b[0;32m    201\u001b[0m     tensors, grad_tensors_, retain_graph, create_graph, inputs,\n\u001b[0;32m    202\u001b[0m     allow_unreachable\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m, accumulate_grad\u001b[39m=\u001b[39;49m\u001b[39mTrue\u001b[39;49;00m)\n",
+      "\u001b[1;31mKeyboardInterrupt\u001b[0m: "
+     ]
+    }
+   ],
+   "source": [
+    "train_loop(train_dataloader, test_dataloader, 1, 5)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mlax-env",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.4"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Model size: (batch_size = 256, seq_len = 128, embed_size = input_size = hidden_size = 192)

Steps Followed:
```
1. Load in the SNLI datasets

2. Tokenize it with roberta-base tokenizer with seq_len = 128

For 1-2 follow the `mlax/examples/lstm.ipynb`

3. Put them in PyTorch dataloaders.

For 3 follow mlax/examples/resnet/resnet_reference.ipynb

4. Create an LSTM model with parameters: vocab_size, embed_size, dropout
- Word embedding layer - torch.nn.Embed of vocab_size and embed_size
- Type embedding layer - torch.nn.Embed with a vocab_size of 2 and embed_size of embed_size, one embedding for question, one for answer

- Element-wise add word embedding and type embedding to get actual embedding
- Bidirectional LSTM with dropout
- Linear projection to make output shape equal to input shape (read torch docs, bidirectional output embedding size is doubled, why?)
- Another bidirectional LSTM with dropout and linear projection
- Another bidirecitional LSTM with dropout and linear projection
- Flatten (reshape) output from (batch_size, seq_len, embed_size) to (batch_size, *)
- Linear projection to 3 outputs

5. Define loss function (cross-entropy) and optimizer (adamw)

6. Define training and testing loops

7. Train model with embed_size = 192 and dropout = 0.1.
```

* Issue To reolve: masking outputs after the output_layer